### PR TITLE
Use separate jobs for build and deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,5 @@ jobs:
         username: ${{ secrets.FTP_USER }}
         password: ${{ secrets.FTP_PASSWORD }}
         protocol: ftps
-        local-dir: ./app/dist/
+        local-dir: ./
         security: strict


### PR DESCRIPTION
Building the code does not look like a deploy event this way. Deploy job only runs on a push (to main).